### PR TITLE
Add build 305 to index.html release

### DIFF
--- a/bin/index.html
+++ b/bin/index.html
@@ -9,20 +9,24 @@
 <h1>Download R Bridge for ArcGIS</h1>
 <hr/>
 
-<h3>Current build: 1.0.1.300:</h3>
+<h3>Current build: 1.0.1.305:</h3>
 <ul>
   <li>Download for R 4.2 (x64)<br/>
+    <a href="windows/contrib/4.2/arcgisbinding_1.0.1.305.zip">arcgisbinding_1.0.1.305.zip</a><br>
     <a href="windows/contrib/4.2/arcgisbinding_1.0.1.300.zip">arcgisbinding_1.0.1.300.zip</a>
   </li>
   <li>Download for R 4.1 (i386, x64)<br/>
-    <a href="windows/contrib/4.1/arcgisbinding_1.0.1.300.zip">arcgisbinding_1.0.1.300.zip</a>
+    <a href="windows/contrib/4.1/arcgisbinding_1.0.1.305.zip">arcgisbinding_1.0.1.305.zip</a><br>
+    <a href="windows/contrib/4.1/arcgisbinding_1.0.1.300.zip">arcgisbinding_1.0.1.300.zip</a><br>
     <a href="windows/contrib/4.1/arcgisbinding_1.0.1.244.zip">arcgisbinding_1.0.1.244.zip</a>
   </li>
   <li>Download for R 4.0 (i386, x64)<br/>
+    <a href="windows/contrib/4.0/arcgisbinding_1.0.1.305.zip">arcgisbinding_1.0.1.305.zip</a>,<br/>
     <a href="windows/contrib/4.0/arcgisbinding_1.0.1.300.zip">arcgisbinding_1.0.1.300.zip</a>,<br/>
     <a href="windows/contrib/4.0/arcgisbinding_1.0.1.244.zip">arcgisbinding_1.0.1.244.zip</a>,<br/>
   </li>
   <li>Download for R 3.5+ (i386, x64)<br/>
+    <a href="windows/contrib/arcgisbinding_1.0.1.305.zip">arcgisbinding_1.0.1.305.zip</a>,<br/>
     <a href="windows/contrib/arcgisbinding_1.0.1.300.zip">arcgisbinding_1.0.1.300.zip</a>,<br/>
     <a href="windows/contrib/arcgisbinding_1.0.1.244.zip">arcgisbinding_1.0.1.244.zip</a>,<br/>
   </li>


### PR DESCRIPTION
This PR modifies `./bin/index.html` to add the 305 build to the downloads page. 